### PR TITLE
Fix compile problem for c++17

### DIFF
--- a/OpenANN/util/Random.h
+++ b/OpenANN/util/Random.h
@@ -107,7 +107,11 @@ public:
     {
       OPENANN_CHECK_EQUALS(result.size(), (size_t) n);
     }
+#if __cplusplus < 201300L		
+    std::random_shuffle(result.begin(), result.end());
+#else
     std::shuffle(result.begin(), result.end());
+#endif
   }
 
   template<class M>

--- a/OpenANN/util/Random.h
+++ b/OpenANN/util/Random.h
@@ -107,7 +107,7 @@ public:
     {
       OPENANN_CHECK_EQUALS(result.size(), (size_t) n);
     }
-    std::random_shuffle(result.begin(), result.end());
+    std::shuffle(result.begin(), result.end());
   }
 
   template<class M>

--- a/src/DataSetView.cpp
+++ b/src/DataSetView.cpp
@@ -49,7 +49,7 @@ void DataSetView::finishIteration(Learner& learner)
 
 DataSetView& DataSetView::shuffle()
 {
-  std::random_shuffle(indices.begin(), indices.end());
+  std::shuffle(indices.begin(), indices.end());
 
   return *this;
 }
@@ -69,7 +69,7 @@ void split(std::vector<DataSetView>& groups, DataSet& dataset,
   int samplesPerGroup = std::floor(dataset.samples() / numberOfGroups + 0.5);
 
   if(shuffling)
-    std::random_shuffle(indices.begin(), indices.end());
+    std::shuffle(indices.begin(), indices.end());
 
   for(int i = 0; i < numberOfGroups; ++i)
   {
@@ -97,7 +97,7 @@ void split(std::vector<DataSetView>& groups, DataSet& dataset, double ratio,
   int samples = std::ceil(ratio * dataset.samples());
 
   if(shuffling)
-    std::random_shuffle(indices.begin(), indices.end());
+    std::shuffle(indices.begin(), indices.end());
 
   groups.push_back(DataSetView(dataset, indices.begin(), indices.begin() + samples));
   groups.push_back(DataSetView(dataset, indices.begin() + samples, indices.end()));

--- a/src/DataSetView.cpp
+++ b/src/DataSetView.cpp
@@ -49,8 +49,11 @@ void DataSetView::finishIteration(Learner& learner)
 
 DataSetView& DataSetView::shuffle()
 {
+#if __cplusplus < 201300L		
+  std::random_shuffle(indices.begin(), indices.end());
+#else
   std::shuffle(indices.begin(), indices.end());
-
+#endif
   return *this;
 }
 
@@ -68,9 +71,14 @@ void split(std::vector<DataSetView>& groups, DataSet& dataset,
 
   int samplesPerGroup = std::floor(dataset.samples() / numberOfGroups + 0.5);
 
-  if(shuffling)
-    std::shuffle(indices.begin(), indices.end());
-
+  if(shuffling) 
+	{
+		#if __cplusplus < 201300L		
+			std::random_shuffle(indices.begin(), indices.end());
+		#else
+			std::shuffle(indices.begin(), indices.end());
+		#endif
+	}
   for(int i = 0; i < numberOfGroups; ++i)
   {
     std::vector<int>::iterator it = indices.begin() + i * samplesPerGroup;
@@ -97,8 +105,13 @@ void split(std::vector<DataSetView>& groups, DataSet& dataset, double ratio,
   int samples = std::ceil(ratio * dataset.samples());
 
   if(shuffling)
-    std::shuffle(indices.begin(), indices.end());
-
+	{
+		#if __cplusplus < 201300L		
+			std::random_shuffle(indices.begin(), indices.end());
+		#else
+			std::shuffle(indices.begin(), indices.end());
+		#endif	
+	}
   groups.push_back(DataSetView(dataset, indices.begin(), indices.begin() + samples));
   groups.push_back(DataSetView(dataset, indices.begin() + samples, indices.end()));
 }


### PR DESCRIPTION
Fixes #182.

The problem that is fixed here was caused by the fact that `std::random_shuffle` has been removed from c++17.  Where the user's code is compiled using `-std=c++17` the call to `random_shuffle` in some headers caused a compile error.

So, what this PR does is to replace `std::random_shuffle` with `std::shuffle` in all the source files of the library.  

The result is that the user code can now use the `-std=c++17` setting.   The change seems safe, but I can confirm only that it works on MacOS.

Here is a comparison of the two methods:
https://www.geeksforgeeks.org/shuffle-vs-random_shuffle-c/
