### PR TITLE
Improve c++17 compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 .kdev4
+.vscode
 *~
 *.backup
 *.orig

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
 project(OpenANN)
-option(CPP_17 "Compile with c++ 17" off) 
 
 find_package(Doxygen)
 find_package(OpenMP)
@@ -52,10 +51,8 @@ set(OPENANN_BRIEF_DESCRIPTION "An open source library for artificial neural netw
 current_time(OPENANN_TIME)
 set(OPENANN_OPTIMIZATION_FLAGS)
 set(OPENANN_PYTHON_COMPILE_ARGS)
-if(CPP_17)
-	compiler_check_add_flag("-std=c++17")
-	compiler_check_add_flag("-Dregister=") # a work-around to get rid of the register keyword
-endif(CPP_17)
+compiler_check_add_flag("-std=c++17")
+compiler_check_add_flag("-Dregister=") # a work-around to get rid of the register keyword
 if(${CMAKE_BUILD_TYPE} STREQUAL Debug)
   message(STATUS "Debug configuration")
   if(CMAKE_COMPILER_IS_GNUCXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
 project(OpenANN)
+option(CPP_17 "Compile with c++ 17" off) 
 
 find_package(Doxygen)
 find_package(OpenMP)
@@ -51,6 +52,10 @@ set(OPENANN_BRIEF_DESCRIPTION "An open source library for artificial neural netw
 current_time(OPENANN_TIME)
 set(OPENANN_OPTIMIZATION_FLAGS)
 set(OPENANN_PYTHON_COMPILE_ARGS)
+if(CPP_17)
+	compiler_check_add_flag("-std=c++17")
+	compiler_check_add_flag("-Dregister=") # a work-around to get rid of the register keyword
+endif(CPP_17)
 if(${CMAKE_BUILD_TYPE} STREQUAL Debug)
   message(STATUS "Debug configuration")
   if(CMAKE_COMPILER_IS_GNUCXX)

--- a/OpenANN/util/Random.h
+++ b/OpenANN/util/Random.h
@@ -119,7 +119,7 @@ public:
 #if __cplusplus < 201300L		
     std::random_shuffle(result.begin(), result.end());
 #else
-    std::shuffle(result.begin(), result.end(),m_generator);
+    std::shuffle(result.begin(), result.end(), m_generator);
 #endif
   }
 

--- a/OpenANN/util/Random.h
+++ b/OpenANN/util/Random.h
@@ -23,7 +23,6 @@ class RandomNumberGenerator
 {
 private:
 	mutable std::mt19937 m_generator;
-	mutable std::uniform_int_distribution<> m_distribution;
 
 public:
   /**

--- a/OpenANN/util/Random.h
+++ b/OpenANN/util/Random.h
@@ -10,6 +10,9 @@
 #include <cmath>
 #include <cstdlib>
 #include <algorithm>
+#if __cplusplus >= 201300L
+#include <random>
+#endif
 
 namespace OpenANN
 {
@@ -20,6 +23,12 @@ namespace OpenANN
  */
 class RandomNumberGenerator
 {
+private:
+#if __cplusplus >= 201300L
+	mutable std::mt19937 m_generator;
+	mutable std::uniform_int_distribution<> m_distribution;
+#endif
+
 public:
   /**
    * Initialize the seed.
@@ -110,7 +119,7 @@ public:
 #if __cplusplus < 201300L		
     std::random_shuffle(result.begin(), result.end());
 #else
-    std::shuffle(result.begin(), result.end());
+    std::shuffle(result.begin(), result.end(),m_generator);
 #endif
   }
 

--- a/OpenANN/util/Random.h
+++ b/OpenANN/util/Random.h
@@ -10,9 +10,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <algorithm>
-#if __cplusplus >= 201300L
 #include <random>
-#endif
 
 namespace OpenANN
 {
@@ -24,10 +22,8 @@ namespace OpenANN
 class RandomNumberGenerator
 {
 private:
-#if __cplusplus >= 201300L
 	mutable std::mt19937 m_generator;
 	mutable std::uniform_int_distribution<> m_distribution;
-#endif
 
 public:
   /**
@@ -116,11 +112,7 @@ public:
     {
       OPENANN_CHECK_EQUALS(result.size(), (size_t) n);
     }
-#if __cplusplus < 201300L		
-    std::random_shuffle(result.begin(), result.end());
-#else
     std::shuffle(result.begin(), result.end(), m_generator);
-#endif
   }
 
   template<class M>

--- a/src/DataSetView.cpp
+++ b/src/DataSetView.cpp
@@ -58,7 +58,7 @@ DataSetView& DataSetView::shuffle()
 #if __cplusplus < 201300L		
   std::random_shuffle(indices.begin(), indices.end());
 #else
-  std::shuffle(indices.begin(), indices.end(),randomGenerator);
+  std::shuffle(indices.begin(), indices.end(), randomGenerator);
 #endif
   return *this;
 }
@@ -82,7 +82,7 @@ void split(std::vector<DataSetView>& groups, DataSet& dataset,
 		#if __cplusplus < 201300L		
 			std::random_shuffle(indices.begin(), indices.end());
 		#else
-			std::shuffle(indices.begin(), indices.end(),randomGenerator);
+			std::shuffle(indices.begin(), indices.end(), randomGenerator);
 		#endif
 	}
   for(int i = 0; i < numberOfGroups; ++i)
@@ -115,7 +115,7 @@ void split(std::vector<DataSetView>& groups, DataSet& dataset, double ratio,
 		#if __cplusplus < 201300L		
 			std::random_shuffle(indices.begin(), indices.end());
 		#else
-			std::shuffle(indices.begin(), indices.end(),randomGenerator);
+			std::shuffle(indices.begin(), indices.end(), randomGenerator);
 		#endif	
 	}
   groups.push_back(DataSetView(dataset, indices.begin(), indices.begin() + samples));

--- a/src/DataSetView.cpp
+++ b/src/DataSetView.cpp
@@ -7,11 +7,10 @@
 #include <cmath>
 #include <cstdlib>
 
-#if __cplusplus >= 201300L
 namespace {
 	std::mt19937 randomGenerator;
 }
-#endif
+
 namespace OpenANN
 {
 
@@ -55,11 +54,7 @@ void DataSetView::finishIteration(Learner& learner)
 
 DataSetView& DataSetView::shuffle()
 {
-#if __cplusplus < 201300L		
-  std::random_shuffle(indices.begin(), indices.end());
-#else
   std::shuffle(indices.begin(), indices.end(), randomGenerator);
-#endif
   return *this;
 }
 
@@ -79,11 +74,7 @@ void split(std::vector<DataSetView>& groups, DataSet& dataset,
 
   if(shuffling) 
 	{
-		#if __cplusplus < 201300L		
-			std::random_shuffle(indices.begin(), indices.end());
-		#else
-			std::shuffle(indices.begin(), indices.end(), randomGenerator);
-		#endif
+	  std::shuffle(indices.begin(), indices.end(), randomGenerator);
 	}
   for(int i = 0; i < numberOfGroups; ++i)
   {
@@ -112,11 +103,7 @@ void split(std::vector<DataSetView>& groups, DataSet& dataset, double ratio,
 
   if(shuffling)
 	{
-		#if __cplusplus < 201300L		
-			std::random_shuffle(indices.begin(), indices.end());
-		#else
-			std::shuffle(indices.begin(), indices.end(), randomGenerator);
-		#endif	
+    std::shuffle(indices.begin(), indices.end(), randomGenerator);
 	}
   groups.push_back(DataSetView(dataset, indices.begin(), indices.begin() + samples));
   groups.push_back(DataSetView(dataset, indices.begin() + samples, indices.end()));

--- a/src/DataSetView.cpp
+++ b/src/DataSetView.cpp
@@ -7,8 +7,14 @@
 #include <cmath>
 #include <cstdlib>
 
+#if __cplusplus >= 201300L
+namespace {
+	std::mt19937 randomGenerator;
+}
+#endif
 namespace OpenANN
 {
+
 
 DataSetView::DataSetView(const DataSetView& ds)
   : indices(ds.indices), dataset(ds.dataset)
@@ -52,7 +58,7 @@ DataSetView& DataSetView::shuffle()
 #if __cplusplus < 201300L		
   std::random_shuffle(indices.begin(), indices.end());
 #else
-  std::shuffle(indices.begin(), indices.end());
+  std::shuffle(indices.begin(), indices.end(),randomGenerator);
 #endif
   return *this;
 }
@@ -76,7 +82,7 @@ void split(std::vector<DataSetView>& groups, DataSet& dataset,
 		#if __cplusplus < 201300L		
 			std::random_shuffle(indices.begin(), indices.end());
 		#else
-			std::shuffle(indices.begin(), indices.end());
+			std::shuffle(indices.begin(), indices.end(),randomGenerator);
 		#endif
 	}
   for(int i = 0; i < numberOfGroups; ++i)
@@ -109,7 +115,7 @@ void split(std::vector<DataSetView>& groups, DataSet& dataset, double ratio,
 		#if __cplusplus < 201300L		
 			std::random_shuffle(indices.begin(), indices.end());
 		#else
-			std::shuffle(indices.begin(), indices.end());
+			std::shuffle(indices.begin(), indices.end(),randomGenerator);
 		#endif	
 	}
   groups.push_back(DataSetView(dataset, indices.begin(), indices.begin() + samples));

--- a/src/DataSetView.cpp
+++ b/src/DataSetView.cpp
@@ -102,9 +102,9 @@ void split(std::vector<DataSetView>& groups, DataSet& dataset, double ratio,
   int samples = std::ceil(ratio * dataset.samples());
 
   if(shuffling)
-	{
+  {
     std::shuffle(indices.begin(), indices.end(), randomGenerator);
-	}
+  }
   groups.push_back(DataSetView(dataset, indices.begin(), indices.begin() + samples));
   groups.push_back(DataSetView(dataset, indices.begin() + samples, indices.end()));
 }

--- a/src/LocalResponseNormalization.cpp
+++ b/src/LocalResponseNormalization.cpp
@@ -50,7 +50,7 @@ void LocalResponseNormalization::forwardPropagate(Eigen::MatrixXd* x,
           const int fmInMax = std::min(fm - 1, fmOut + n / 2);
           for(int fmIn = fmInMin; fmIn < fmInMax; fmIn++)
           {
-            register double a = (*x)(n, fmIn * fmSize + r * cols + c);
+            double a = (*x)(n, fmIn * fmSize + r * cols + c);
             denom += a * a;
           }
           denom = k + alpha * denom;

--- a/src/Normalization.cpp
+++ b/src/Normalization.cpp
@@ -20,7 +20,7 @@ Transformer& Normalization::fit(const Eigen::MatrixXd& X)
   {
     for(int d = 0; d < X.cols(); ++d)
     {
-      register double tmp = X(n, d) - mean(d);
+      double tmp = X(n, d) - mean(d);
       std(0, d) += tmp*tmp;
     }
   }

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -6,17 +6,25 @@ namespace OpenANN
 
 RandomNumberGenerator::RandomNumberGenerator()
 {
+#if __cplusplus < 201300L
   static bool seedInitialized = false;
   if(!seedInitialized)
   {
     srand(std::time(0));
     seedInitialized = true;
   }
+#else	
+	m_generator.seed(std::time(0));
+#endif
 }
 
 void RandomNumberGenerator::seed(unsigned int seed)
 {
+#if __cplusplus < 201300L
   srand(seed);
+#else	
+	m_generator.seed(seed);
+#endif
 }
 
 int RandomNumberGenerator::generateInt(int min, int range) const
@@ -25,7 +33,11 @@ int RandomNumberGenerator::generateInt(int min, int range) const
   if(range == 0)
     return min;
   else
+#if __cplusplus < 201300L
     return rand() % range + min;
+#else 
+		return m_distribution(m_generator) % range + min;
+#endif		
 }
 
 size_t RandomNumberGenerator::generateIndex(size_t size) const

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -6,12 +6,19 @@ namespace OpenANN
 
 RandomNumberGenerator::RandomNumberGenerator()
 {
+	static bool seedInitialized = false;
+  if(!seedInitialized)
+  {
+    srand(std::time(0));
+    seedInitialized = true;
+  }
   m_generator.seed(std::time(0));
 }
 
 void RandomNumberGenerator::seed(unsigned int seed)
 {
-	m_generator.seed(seed);
+  srand(seed);
+  m_generator.seed(seed);
 }
 
 int RandomNumberGenerator::generateInt(int min, int range) const
@@ -20,7 +27,7 @@ int RandomNumberGenerator::generateInt(int min, int range) const
   if(range == 0)
     return min;
   else
-    return m_distribution(m_generator) % range + min;
+    return rand() % range + min;
 }
 
 size_t RandomNumberGenerator::generateIndex(size_t size) const

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -6,25 +6,12 @@ namespace OpenANN
 
 RandomNumberGenerator::RandomNumberGenerator()
 {
-#if __cplusplus < 201300L
-  static bool seedInitialized = false;
-  if(!seedInitialized)
-  {
-    srand(std::time(0));
-    seedInitialized = true;
-  }
-#else	
-	m_generator.seed(std::time(0));
-#endif
+  m_generator.seed(std::time(0));
 }
 
 void RandomNumberGenerator::seed(unsigned int seed)
 {
-#if __cplusplus < 201300L
-  srand(seed);
-#else	
 	m_generator.seed(seed);
-#endif
 }
 
 int RandomNumberGenerator::generateInt(int min, int range) const
@@ -33,11 +20,7 @@ int RandomNumberGenerator::generateInt(int min, int range) const
   if(range == 0)
     return min;
   else
-#if __cplusplus < 201300L
-    return rand() % range + min;
-#else 
-		return m_distribution(m_generator) % range + min;
-#endif		
+    return m_distribution(m_generator) % range + min;
 }
 
 size_t RandomNumberGenerator::generateIndex(size_t size) const

--- a/test/IODataSetTestCase.cpp
+++ b/test/IODataSetTestCase.cpp
@@ -95,7 +95,7 @@ void IODataSetTestCase::saveFANN()
 
   ASSERT_EQUALS(str.str(),
                 "2 2 1\n"
-                "1.5 0\n"
+                "1.5   0\n"
                 "1\n"
                 "  0 1.5\n"
                 "0\n");


### PR DESCRIPTION
Follows on from #183

Fixes use of non-standard shuffle.

Changed the build to use `c++17`
